### PR TITLE
Fix Astro image build flags

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
       exclude: ["@resvg/resvg-js"],
     },
   },
+  experimental: {
+    responsiveImages: true,
+    svg: true,
+  },
   image: {
     // Used for all Markdown images; not configurable per-image
     // Used for all `<Image />` and `<Picture />` components unless overridden with a prop


### PR DESCRIPTION
## Summary
- enable responsive images
- enable `svg` component support

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68617662bdf4832fb6c8257cb22576b1